### PR TITLE
[feature]ランキング履歴比較機能を追加

### DIFF
--- a/.github/workflows/daily-ranking.yml
+++ b/.github/workflows/daily-ranking.yml
@@ -9,10 +9,14 @@ on:
 jobs:
   send-ranking:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: リポジトリをチェックアウト
       uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: uvをインストール
       uses: astral-sh/setup-uv@v4
@@ -32,3 +36,11 @@ jobs:
         LINE_USER_ID: ${{ secrets.LINE_USER_ID }}
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: uv run python src/main.py
+
+    - name: 履歴ファイルをコミット
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add ranking_history.json
+        git diff --cached --quiet || git commit -m "chore: ランキング履歴を更新 [skip ci]"
+        git push origin main

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ GitHub Actionsを使用して、毎日朝6時に自動実行されます。
   - https://www.amazon.co.jp/gp/bestsellers/digital-text/2275256051
 - スクレイピングしたデータをLINE Messaging APIを使ってLINEに通知
 - GitHub Actionsによる定期実行（毎日午前6時）
+- **Gemini APIによるランキング変化の要約機能**
+  - 前回のランキングと比較して変化を分析
+  - 新規ランクイン、順位変動、ランク外などを2-3文で簡潔にレポート
+  - 履歴は直近3回分を保存
 
 ### 通知例
 1位|タイトル
@@ -32,6 +36,8 @@ GitHub Secretsまたはローカルの.envファイルに以下の環境変数�
 
 ### オプション
 - `KINDLE_RANKING_LIMIT`: 取得するランキング件数（デフォルト: 10）
+- `GEMINI_API_KEY`: Gemini APIキー（ランキング変化の要約機能を有効にする場合）
+- `ENABLE_GEMINI_SUMMARY`: Gemini要約機能の有効/無効（デフォルト: true）
 - `LOG_LEVEL`: ログレベル（デフォルト: INFO）
 
 ## 開発環境のセットアップ

--- a/src/history_manager.py
+++ b/src/history_manager.py
@@ -1,0 +1,150 @@
+"""
+ランキング履歴を管理するモジュール
+直近3回分のランキングデータをJSONファイルに保存
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+HISTORY_FILE = "ranking_history.json"
+MAX_HISTORY_COUNT = 3
+
+
+def load_history() -> List[Dict]:
+    """
+    履歴ファイルからランキング履歴を読み込む
+    
+    Returns:
+        履歴データのリスト（新しい順）
+    """
+    history_path = Path(HISTORY_FILE)
+    
+    if not history_path.exists():
+        logger.info("履歴ファイルが存在しません。新規作成します。")
+        return []
+    
+    try:
+        with open(history_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data.get("history", [])
+    except Exception as e:
+        logger.error(f"履歴ファイルの読み込みでエラー: {e}")
+        return []
+
+
+def save_history(history: List[Dict]) -> None:
+    """
+    履歴データをファイルに保存
+    
+    Args:
+        history: 保存する履歴データ
+    """
+    try:
+        with open(HISTORY_FILE, "w", encoding="utf-8") as f:
+            json.dump({"history": history}, f, ensure_ascii=False, indent=2)
+        logger.info(f"履歴ファイルを保存しました: {len(history)}件")
+    except Exception as e:
+        logger.error(f"履歴ファイルの保存でエラー: {e}")
+        raise
+
+
+def add_ranking_to_history(ranking_data: List[Dict]) -> None:
+    """
+    新しいランキングデータを履歴に追加
+    
+    Args:
+        ranking_data: スクレイピングで取得したランキングデータ
+    """
+    history = load_history()
+    
+    # 新しいエントリを作成
+    new_entry = {
+        "timestamp": datetime.now().isoformat(),
+        "rankings": ranking_data
+    }
+    
+    # 履歴の先頭に追加
+    history.insert(0, new_entry)
+    
+    # 最大保存数を超えた分を削除
+    if len(history) > MAX_HISTORY_COUNT:
+        history = history[:MAX_HISTORY_COUNT]
+    
+    save_history(history)
+
+
+def get_previous_rankings() -> Optional[List[Dict]]:
+    """
+    直前のランキングデータを取得
+    
+    Returns:
+        直前のランキングデータ（存在しない場合はNone）
+    """
+    history = load_history()
+    
+    if len(history) >= 2:
+        # 最新のものは今回のデータなので、2番目を返す
+        return history[1]["rankings"]
+    elif len(history) == 1:
+        # 初回実行後の2回目の場合
+        return history[0]["rankings"]
+    else:
+        return None
+
+
+def analyze_ranking_changes(current: List[Dict], previous: List[Dict]) -> Dict:
+    """
+    現在と過去のランキングを比較して変化を分析
+    
+    Args:
+        current: 現在のランキングデータ
+        previous: 過去のランキングデータ
+    
+    Returns:
+        分析結果を含む辞書
+    """
+    analysis = {
+        "new_entries": [],
+        "rank_changes": [],
+        "dropped_out": []
+    }
+    
+    # タイトルをキーにした辞書を作成
+    current_dict = {item["title"]: item for item in current}
+    previous_dict = {item["title"]: item for item in previous}
+    
+    # 新規エントリーを検出
+    for title in current_dict:
+        if title not in previous_dict:
+            analysis["new_entries"].append({
+                "title": title,
+                "rank": current_dict[title]["rank"]
+            })
+    
+    # ランク変動を検出
+    for title in current_dict:
+        if title in previous_dict:
+            current_rank = current_dict[title]["rank"]
+            previous_rank = previous_dict[title]["rank"]
+            if current_rank != previous_rank:
+                analysis["rank_changes"].append({
+                    "title": title,
+                    "current_rank": current_rank,
+                    "previous_rank": previous_rank,
+                    "change": previous_rank - current_rank  # 正の値は上昇
+                })
+    
+    # ランキング外に落ちた作品を検出
+    for title in previous_dict:
+        if title not in current_dict:
+            analysis["dropped_out"].append({
+                "title": title,
+                "previous_rank": previous_dict[title]["rank"]
+            })
+    
+    return analysis

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,18 @@ import logging
 import sys
 
 from config import config
+from history_manager import (
+    add_ranking_to_history,
+    analyze_ranking_changes,
+    get_previous_rankings,
+)
 from notifier import send_line_message
-from scraper import get_amazon_kindle_ranking
-from summarizer import format_message_with_summary, generate_ranking_summary
+from scraper import get_amazon_kindle_ranking_with_data
+from summarizer import (
+    format_message_with_summary,
+    generate_first_ranking_summary,
+    generate_ranking_changes_summary,
+)
 
 # ロガーの設定
 logging.basicConfig(
@@ -23,19 +32,36 @@ def main():
         logger.info("Kindleランキング取得処理を開始します...")
         logger.info(f"ランキング取得件数: {config.kindle_ranking_limit}")
 
-        # Kindleランキング情報を取得
-        ranking_text = get_amazon_kindle_ranking(limit=config.kindle_ranking_limit)
+        # Kindleランキング情報を取得（構造化データも含む）
+        ranking_text, ranking_data = get_amazon_kindle_ranking_with_data(limit=config.kindle_ranking_limit)
         logger.info(f"ランキング取得成功: {len(ranking_text)}文字")
 
+        # 履歴から前回のランキングを取得
+        previous_rankings = get_previous_rankings()
+        
         # Gemini APIで要約を生成（設定が有効な場合）
         summary = None
         if config.enable_gemini_summary:
             logger.info("Gemini要約機能が有効です...")
-            summary = generate_ranking_summary(ranking_text)
+            
+            if previous_rankings:
+                # 前回のデータがある場合は変化を分析
+                logger.info("前回のランキングデータが存在します。変化を分析中...")
+                changes_analysis = analyze_ranking_changes(ranking_data, previous_rankings)
+                summary = generate_ranking_changes_summary(changes_analysis, ranking_text)
+            else:
+                # 初回実行の場合は通常の要約
+                logger.info("初回実行のため、通常の要約を生成します...")
+                summary = generate_first_ranking_summary(ranking_text)
+            
             if summary:
                 logger.info(f"要約生成成功: {len(summary)}文字")
             else:
                 logger.warning("要約生成に失敗しました（従来のランキングのみ送信）")
+
+        # ランキングデータを履歴に保存
+        add_ranking_to_history(ranking_data)
+        logger.info("ランキングデータを履歴に保存しました")
 
         # ランキングと要約を組み合わせて最終メッセージを作成
         final_message = format_message_with_summary(ranking_text, summary)

--- a/src/main.py
+++ b/src/main.py
@@ -38,12 +38,12 @@ def main():
 
         # 履歴から前回のランキングを取得
         previous_rankings = get_previous_rankings()
-        
+
         # Gemini APIで要約を生成（設定が有効な場合）
         summary = None
         if config.enable_gemini_summary:
             logger.info("Gemini要約機能が有効です...")
-            
+
             if previous_rankings:
                 # 前回のデータがある場合は変化を分析
                 logger.info("前回のランキングデータが存在します。変化を分析中...")
@@ -53,7 +53,7 @@ def main():
                 # 初回実行の場合は通常の要約
                 logger.info("初回実行のため、通常の要約を生成します...")
                 summary = generate_first_ranking_summary(ranking_text)
-            
+
             if summary:
                 logger.info(f"要約生成成功: {len(summary)}文字")
             else:

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -158,7 +158,7 @@ def get_amazon_kindle_ranking(limit=10, max_retries=3) -> str:
 def get_amazon_kindle_ranking_with_data(limit=10, max_retries=3) -> tuple[str, List[dict]]:
     """
     Amazonの Kindle ランキングを取得して文字列と構造化データの両方を返す
-    
+
     Returns:
         tuple: (表示用文字列, 構造化データのリスト)
     """
@@ -168,17 +168,19 @@ def get_amazon_kindle_ranking_with_data(limit=10, max_retries=3) -> tuple[str, L
     # 書籍リストを文字列に変換
     result_lines = []
     structured_data = []
-    
+
     for book in books:
         result_lines.append(book.to_string())
         # 構造化データとして保存
-        structured_data.append({
-            "rank": book.rank,
-            "title": book.title,
-            "rating": book.rating,
-            "review_count": book.review_count,
-            "price": book.price,
-            "url": book.url
-        })
+        structured_data.append(
+            {
+                "rank": book.rank,
+                "title": book.title,
+                "rating": book.rating,
+                "review_count": book.review_count,
+                "price": book.price,
+                "url": book.url,
+            }
+        )
 
     return "\n\n".join(result_lines), structured_data

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -153,3 +153,32 @@ def get_amazon_kindle_ranking(limit=10, max_retries=3) -> str:
         result_lines.append(book.to_string())
 
     return "\n\n".join(result_lines)
+
+
+def get_amazon_kindle_ranking_with_data(limit=10, max_retries=3) -> tuple[str, List[dict]]:
+    """
+    Amazonの Kindle ランキングを取得して文字列と構造化データの両方を返す
+    
+    Returns:
+        tuple: (表示用文字列, 構造化データのリスト)
+    """
+    soup = _fetch_amazon_page(max_retries)
+    books = _parse_books_from_soup(soup, limit)
+
+    # 書籍リストを文字列に変換
+    result_lines = []
+    structured_data = []
+    
+    for book in books:
+        result_lines.append(book.to_string())
+        # 構造化データとして保存
+        structured_data.append({
+            "rank": book.rank,
+            "title": book.title,
+            "rating": book.rating,
+            "review_count": book.review_count,
+            "price": book.price,
+            "url": book.url
+        })
+
+    return "\n\n".join(result_lines), structured_data

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -3,7 +3,7 @@ Gemini APIを使用してKindleランキングデータの要約を生成する�
 """
 
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 from google import genai
 from google.genai import errors as genai_errors
@@ -13,34 +13,49 @@ from config import config
 
 logger = logging.getLogger(__name__)
 
-# Gemini API用のシステム指示
-SYSTEM_INSTRUCTION = """
+# Gemini API用のシステム指示（変化分析用）
+SYSTEM_INSTRUCTION_CHANGES = """
 あなたはKindle電子書籍の売れ筋ランキング分析の専門家です。
-与えられたランキングデータを分析して、読者に興味深い洞察を提供してください。
+前回と今回のランキングを比較して、重要な変化を2-3文で簡潔に報告してください。
 
-以下の形式で要約を作成してください：
-📊 **今日のKindleランキング分析**
+以下の点に注目してください：
+- 新たにランクインした注目作品
+- 大きく順位が変動した作品
+- ランキングのトレンドの変化
 
-🔥 **注目ポイント**
-- ランキング上位の特徴やトレンド
-- 人気ジャンルの傾向
-
-⭐ **おすすめ作品**
-- 特に評価が高い（★4.0以上）作品を1-2冊
-
-💡 **読書のヒント**
-- 今のトレンドに基づく一言コメント
-
-文字数は200文字程度で簡潔にまとめてください。
+絵文字を使って分かりやすく、重要な変化のみを報告してください。
 """
 
-# プロンプトテンプレート
-PROMPT_TEMPLATE = """
-以下はAmazon Kindle売れ筋ランキングのデータです：
+# Gemini API用のシステム指示（初回分析用）
+SYSTEM_INSTRUCTION_FIRST = """
+あなたはKindle電子書籍の売れ筋ランキング分析の専門家です。
+今回のランキングの特徴を2-3文で簡潔に報告してください。
 
+以下の点に注目してください：
+- 上位作品の傾向
+- 人気ジャンル
+- 高評価作品
+
+絵文字を使って分かりやすく報告してください。
+"""
+
+# プロンプトテンプレート（変化分析用）
+PROMPT_TEMPLATE_CHANGES = """
+前回と今回のKindleランキングの変化を分析してください。
+
+【変化の内容】
+{changes_text}
+
+【今回のランキング】
+{current_ranking}
+"""
+
+# プロンプトテンプレート（初回分析用）
+PROMPT_TEMPLATE_FIRST = """
+今回のKindleランキングを分析してください。
+
+【ランキング】
 {ranking_text}
-
-このデータを分析して要約してください。
 """
 
 
@@ -75,9 +90,53 @@ def _call_gemini_api(prompt: str, system_instruction: str) -> str:
     return response.text.strip()
 
 
-def generate_ranking_summary(ranking_text: str) -> Optional[str]:
+def generate_ranking_changes_summary(changes_analysis: Dict, current_ranking_text: str) -> Optional[str]:
     """
-    Gemini APIを使ってKindleランキングの要約を生成
+    Gemini APIを使ってランキングの変化を要約
+
+    Args:
+        changes_analysis: 変化分析の結果
+        current_ranking_text: 現在のランキングテキスト
+
+    Returns:
+        要約テキスト（失敗時はNone）
+    """
+    if not config.enable_gemini_summary or not config.gemini_api_key:
+        logger.info("Gemini要約が無効または、APIキーが設定されていません")
+        return None
+
+    try:
+        logger.info("Gemini APIを使用して変化の要約を生成中...")
+
+        # 変化の内容をテキスト化
+        changes_text = _format_changes_for_prompt(changes_analysis)
+        
+        # プロンプトを作成
+        prompt = PROMPT_TEMPLATE_CHANGES.format(
+            changes_text=changes_text,
+            current_ranking=current_ranking_text
+        )
+
+        # API呼び出し
+        summary = _call_gemini_api(prompt, SYSTEM_INSTRUCTION_CHANGES)
+
+        logger.info(f"Gemini変化要約生成成功: {len(summary)}文字")
+        return summary
+
+    except genai_errors.APIError as e:
+        logger.error(f"Gemini API呼び出しでエラーが発生しました: {str(e)}")
+        return None
+    except ValueError as e:
+        logger.error(f"Gemini APIレスポンスの処理でエラーが発生しました: {str(e)}")
+        return None
+    except Exception as e:
+        logger.error(f"予期しないエラーが発生しました: {type(e).__name__}: {str(e)}")
+        return None
+
+
+def generate_first_ranking_summary(ranking_text: str) -> Optional[str]:
+    """
+    Gemini APIを使って初回のランキング要約を生成
 
     Args:
         ranking_text: スクレイピングで取得したランキングデータ
@@ -90,15 +149,15 @@ def generate_ranking_summary(ranking_text: str) -> Optional[str]:
         return None
 
     try:
-        logger.info("Gemini APIを使用して要約を生成中...")
+        logger.info("Gemini APIを使用して初回要約を生成中...")
 
         # プロンプトを作成
-        prompt = PROMPT_TEMPLATE.format(ranking_text=ranking_text)
+        prompt = PROMPT_TEMPLATE_FIRST.format(ranking_text=ranking_text)
 
         # API呼び出し
-        summary = _call_gemini_api(prompt, SYSTEM_INSTRUCTION)
+        summary = _call_gemini_api(prompt, SYSTEM_INSTRUCTION_FIRST)
 
-        logger.info(f"Gemini要約生成成功: {len(summary)}文字")
+        logger.info(f"Gemini初回要約生成成功: {len(summary)}文字")
         return summary
 
     except genai_errors.APIError as e:
@@ -110,6 +169,36 @@ def generate_ranking_summary(ranking_text: str) -> Optional[str]:
     except Exception as e:
         logger.error(f"予期しないエラーが発生しました: {type(e).__name__}: {str(e)}")
         return None
+
+
+def _format_changes_for_prompt(analysis: Dict) -> str:
+    """
+    変化分析結果をプロンプト用のテキストに整形
+    """
+    lines = []
+    
+    if analysis["new_entries"]:
+        lines.append("【新規ランクイン】")
+        for entry in analysis["new_entries"][:3]:  # 上位3つまで
+            lines.append(f"- {entry['rank']}位: {entry['title']}")
+    
+    if analysis["rank_changes"]:
+        # 大きな変動のみ抽出（3位以上の変動）
+        big_changes = [c for c in analysis["rank_changes"] if abs(c["change"]) >= 3]
+        if big_changes:
+            lines.append("\n【大きな順位変動】")
+            for change in sorted(big_changes, key=lambda x: abs(x["change"]), reverse=True)[:3]:
+                if change["change"] > 0:
+                    lines.append(f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↑{change['change']}）")
+                else:
+                    lines.append(f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↓{abs(change['change'])}）")
+    
+    if analysis["dropped_out"]:
+        lines.append("\n【ランク外】")
+        for entry in analysis["dropped_out"][:2]:  # 上位2つまで
+            lines.append(f"- {entry['title']}（前回{entry['previous_rank']}位）")
+    
+    return "\n".join(lines)
 
 
 def format_message_with_summary(ranking_text: str, summary: Optional[str] = None) -> str:

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -110,12 +110,9 @@ def generate_ranking_changes_summary(changes_analysis: Dict, current_ranking_tex
 
         # 変化の内容をテキスト化
         changes_text = _format_changes_for_prompt(changes_analysis)
-        
+
         # プロンプトを作成
-        prompt = PROMPT_TEMPLATE_CHANGES.format(
-            changes_text=changes_text,
-            current_ranking=current_ranking_text
-        )
+        prompt = PROMPT_TEMPLATE_CHANGES.format(changes_text=changes_text, current_ranking=current_ranking_text)
 
         # API呼び出し
         summary = _call_gemini_api(prompt, SYSTEM_INSTRUCTION_CHANGES)
@@ -176,12 +173,12 @@ def _format_changes_for_prompt(analysis: Dict) -> str:
     変化分析結果をプロンプト用のテキストに整形
     """
     lines = []
-    
+
     if analysis["new_entries"]:
         lines.append("【新規ランクイン】")
         for entry in analysis["new_entries"][:3]:  # 上位3つまで
             lines.append(f"- {entry['rank']}位: {entry['title']}")
-    
+
     if analysis["rank_changes"]:
         # 大きな変動のみ抽出（3位以上の変動）
         big_changes = [c for c in analysis["rank_changes"] if abs(c["change"]) >= 3]
@@ -189,15 +186,19 @@ def _format_changes_for_prompt(analysis: Dict) -> str:
             lines.append("\n【大きな順位変動】")
             for change in sorted(big_changes, key=lambda x: abs(x["change"]), reverse=True)[:3]:
                 if change["change"] > 0:
-                    lines.append(f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↑{change['change']}）")
+                    lines.append(
+                        f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↑{change['change']}）"
+                    )
                 else:
-                    lines.append(f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↓{abs(change['change'])}）")
-    
+                    lines.append(
+                        f"- {change['title']}: {change['previous_rank']}位→{change['current_rank']}位（↓{abs(change['change'])}）"
+                    )
+
     if analysis["dropped_out"]:
         lines.append("\n【ランク外】")
         for entry in analysis["dropped_out"][:2]:  # 上位2つまで
             lines.append(f"- {entry['title']}（前回{entry['previous_rank']}位）")
-    
+
     return "\n".join(lines)
 
 

--- a/tests/test_history_manager.py
+++ b/tests/test_history_manager.py
@@ -3,12 +3,12 @@
 """
 
 import json
+import os
 import tempfile
+import unittest
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from src.history_manager import (
     add_ranking_to_history,
@@ -19,161 +19,167 @@ from src.history_manager import (
 )
 
 
-@pytest.fixture
-def sample_ranking_data():
-    """テスト用のランキングデータ"""
-    return [
-        {
-            "rank": 1,
-            "title": "テスト書籍1",
-            "rating": 4.5,
-            "review_count": 100,
-            "price": "¥500",
-            "url": "https://example.com/1"
-        },
-        {
-            "rank": 2,
-            "title": "テスト書籍2",
-            "rating": 4.0,
-            "review_count": 50,
-            "price": "¥1000",
-            "url": "https://example.com/2"
-        }
-    ]
-
-
-@pytest.fixture
-def temp_history_file():
-    """一時的な履歴ファイルを作成"""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        temp_path = f.name
+class TestHistoryManager(unittest.TestCase):
+    """履歴管理機能のテストクラス"""
     
-    # history_manager.HISTORY_FILEをパッチ
-    with patch('src.history_manager.HISTORY_FILE', temp_path):
-        yield temp_path
+    def setUp(self):
+        """各テストの前に実行される"""
+        # 一時ファイルを作成
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.json')
+        os.close(self.temp_fd)
+        
+        # パッチを適用
+        self.patcher = patch('src.history_manager.HISTORY_FILE', self.temp_path)
+        self.patcher.start()
+        
+        # サンプルデータ
+        self.sample_ranking_data = [
+            {
+                "rank": 1,
+                "title": "テスト書籍1",
+                "rating": 4.5,
+                "review_count": 100,
+                "price": "¥500",
+                "url": "https://example.com/1"
+            },
+            {
+                "rank": 2,
+                "title": "テスト書籍2",
+                "rating": 4.0,
+                "review_count": 50,
+                "price": "¥1000",
+                "url": "https://example.com/2"
+            }
+        ]
     
-    # クリーンアップ
-    Path(temp_path).unlink(missing_ok=True)
+    def tearDown(self):
+        """各テストの後に実行される"""
+        # パッチを解除
+        self.patcher.stop()
+        
+        # 一時ファイルを削除
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
 
 
-def test_load_empty_history(temp_history_file):
-    """空の履歴を読み込むテスト"""
-    history = load_history()
-    assert history == []
+    def test_load_empty_history(self):
+        """空の履歴を読み込むテスト"""
+        history = load_history()
+        self.assertEqual(history, [])
+
+    def test_save_and_load_history(self):
+        """履歴の保存と読み込みテスト"""
+        history_data = [{
+            "timestamp": datetime.now().isoformat(),
+            "rankings": self.sample_ranking_data
+        }]
+        
+        save_history(history_data)
+        loaded = load_history()
+        
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0]["rankings"], self.sample_ranking_data)
+
+    def test_add_ranking_to_history(self):
+        """ランキングを履歴に追加するテスト"""
+        # 初回追加
+        add_ranking_to_history(self.sample_ranking_data)
+        history = load_history()
+        
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0]["rankings"], self.sample_ranking_data)
+        
+        # 2回目追加
+        new_data = self.sample_ranking_data.copy()
+        new_data[0] = new_data[0].copy()
+        new_data[0]["title"] = "新しい書籍"
+        add_ranking_to_history(new_data)
+        history = load_history()
+        
+        self.assertEqual(len(history), 2)
+        self.assertEqual(history[0]["rankings"][0]["title"], "新しい書籍")  # 最新が先頭
+        self.assertEqual(history[1]["rankings"], self.sample_ranking_data)  # 古いデータが後ろ
+
+    def test_max_history_limit(self):
+        """履歴の最大保存数テスト"""
+        # 4回追加（最大3回分なので、最後の3つが残る）
+        for i in range(4):
+            data = self.sample_ranking_data.copy()
+            data[0] = data[0].copy()
+            data[0]["title"] = f"書籍{i}"
+            add_ranking_to_history(data)
+        
+        history = load_history()
+        self.assertEqual(len(history), 3)
+        self.assertEqual(history[0]["rankings"][0]["title"], "書籍3")  # 最新
+        self.assertEqual(history[2]["rankings"][0]["title"], "書籍1")  # 最古（書籍0は削除済み）
+
+    def test_get_previous_rankings_empty(self):
+        """履歴が空の場合の前回ランキング取得テスト"""
+        self.assertIsNone(get_previous_rankings())
+
+    def test_get_previous_rankings_single(self):
+        """履歴が1つの場合の前回ランキング取得テスト"""
+        add_ranking_to_history(self.sample_ranking_data)
+        # 初回実行後なので、その履歴を返す
+        self.assertEqual(get_previous_rankings(), self.sample_ranking_data)
+
+    def test_get_previous_rankings_multiple(self):
+        """履歴が複数の場合の前回ランキング取得テスト"""
+        # 1回目
+        add_ranking_to_history(self.sample_ranking_data)
+        
+        # 2回目
+        new_data = self.sample_ranking_data.copy()
+        new_data[0] = new_data[0].copy()
+        new_data[0]["title"] = "新しい書籍"
+        add_ranking_to_history(new_data)
+        
+        # 2番目（前回）のデータが返される
+        previous = get_previous_rankings()
+        self.assertEqual(previous, self.sample_ranking_data)
+
+    def test_analyze_ranking_changes(self):
+        """ランキング変化分析のテスト"""
+        current = [
+            {"rank": 1, "title": "書籍A"},  # 前回2位から上昇
+            {"rank": 2, "title": "書籍D"},  # 新規エントリー
+            {"rank": 3, "title": "書籍B"},  # 前回1位から下降
+        ]
+        
+        previous = [
+            {"rank": 1, "title": "書籍B"},
+            {"rank": 2, "title": "書籍A"},
+            {"rank": 3, "title": "書籍C"},  # ランク外へ
+        ]
+        
+        analysis = analyze_ranking_changes(current, previous)
+        
+        # 新規エントリー
+        self.assertEqual(len(analysis["new_entries"]), 1)
+        self.assertEqual(analysis["new_entries"][0]["title"], "書籍D")
+        self.assertEqual(analysis["new_entries"][0]["rank"], 2)
+        
+        # ランク変動
+        self.assertEqual(len(analysis["rank_changes"]), 2)
+        
+        # 書籍Aの上昇を確認
+        book_a_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍A")
+        self.assertEqual(book_a_change["current_rank"], 1)
+        self.assertEqual(book_a_change["previous_rank"], 2)
+        self.assertEqual(book_a_change["change"], 1)  # 上昇
+        
+        # 書籍Bの下降を確認
+        book_b_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍B")
+        self.assertEqual(book_b_change["current_rank"], 3)
+        self.assertEqual(book_b_change["previous_rank"], 1)
+        self.assertEqual(book_b_change["change"], -2)  # 下降
+        
+        # ランク外
+        self.assertEqual(len(analysis["dropped_out"]), 1)
+        self.assertEqual(analysis["dropped_out"][0]["title"], "書籍C")
+        self.assertEqual(analysis["dropped_out"][0]["previous_rank"], 3)
 
 
-def test_save_and_load_history(temp_history_file, sample_ranking_data):
-    """履歴の保存と読み込みテスト"""
-    history_data = [{
-        "timestamp": datetime.now().isoformat(),
-        "rankings": sample_ranking_data
-    }]
-    
-    save_history(history_data)
-    loaded = load_history()
-    
-    assert len(loaded) == 1
-    assert loaded[0]["rankings"] == sample_ranking_data
-
-
-def test_add_ranking_to_history(temp_history_file, sample_ranking_data):
-    """ランキングを履歴に追加するテスト"""
-    # 初回追加
-    add_ranking_to_history(sample_ranking_data)
-    history = load_history()
-    
-    assert len(history) == 1
-    assert history[0]["rankings"] == sample_ranking_data
-    
-    # 2回目追加
-    new_data = sample_ranking_data.copy()
-    new_data[0]["title"] = "新しい書籍"
-    add_ranking_to_history(new_data)
-    history = load_history()
-    
-    assert len(history) == 2
-    assert history[0]["rankings"][0]["title"] == "新しい書籍"  # 最新が先頭
-    assert history[1]["rankings"] == sample_ranking_data  # 古いデータが後ろ
-
-
-def test_max_history_limit(temp_history_file, sample_ranking_data):
-    """履歴の最大保存数テスト"""
-    # 4回追加（最大3回分なので、最後の3つが残る）
-    for i in range(4):
-        data = sample_ranking_data.copy()
-        data[0]["title"] = f"書籍{i}"
-        add_ranking_to_history(data)
-    
-    history = load_history()
-    assert len(history) == 3
-    assert history[0]["rankings"][0]["title"] == "書籍3"  # 最新
-    assert history[2]["rankings"][0]["title"] == "書籍1"  # 最古（書籍0は削除済み）
-
-
-def test_get_previous_rankings_empty(temp_history_file):
-    """履歴が空の場合の前回ランキング取得テスト"""
-    assert get_previous_rankings() is None
-
-
-def test_get_previous_rankings_single(temp_history_file, sample_ranking_data):
-    """履歴が1つの場合の前回ランキング取得テスト"""
-    add_ranking_to_history(sample_ranking_data)
-    # 初回実行後なので、その履歴を返す
-    assert get_previous_rankings() == sample_ranking_data
-
-
-def test_get_previous_rankings_multiple(temp_history_file, sample_ranking_data):
-    """履歴が複数の場合の前回ランキング取得テスト"""
-    # 1回目
-    add_ranking_to_history(sample_ranking_data)
-    
-    # 2回目
-    new_data = sample_ranking_data.copy()
-    new_data[0]["title"] = "新しい書籍"
-    add_ranking_to_history(new_data)
-    
-    # 2番目（前回）のデータが返される
-    previous = get_previous_rankings()
-    assert previous == sample_ranking_data
-
-
-def test_analyze_ranking_changes():
-    """ランキング変化分析のテスト"""
-    current = [
-        {"rank": 1, "title": "書籍A"},  # 前回2位から上昇
-        {"rank": 2, "title": "書籍D"},  # 新規エントリー
-        {"rank": 3, "title": "書籍B"},  # 前回1位から下降
-    ]
-    
-    previous = [
-        {"rank": 1, "title": "書籍B"},
-        {"rank": 2, "title": "書籍A"},
-        {"rank": 3, "title": "書籍C"},  # ランク外へ
-    ]
-    
-    analysis = analyze_ranking_changes(current, previous)
-    
-    # 新規エントリー
-    assert len(analysis["new_entries"]) == 1
-    assert analysis["new_entries"][0]["title"] == "書籍D"
-    assert analysis["new_entries"][0]["rank"] == 2
-    
-    # ランク変動
-    assert len(analysis["rank_changes"]) == 2
-    
-    # 書籍Aの上昇を確認
-    book_a_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍A")
-    assert book_a_change["current_rank"] == 1
-    assert book_a_change["previous_rank"] == 2
-    assert book_a_change["change"] == 1  # 上昇
-    
-    # 書籍Bの下降を確認
-    book_b_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍B")
-    assert book_b_change["current_rank"] == 3
-    assert book_b_change["previous_rank"] == 1
-    assert book_b_change["change"] == -2  # 下降
-    
-    # ランク外
-    assert len(analysis["dropped_out"]) == 1
-    assert analysis["dropped_out"][0]["title"] == "書籍C"
-    assert analysis["dropped_out"][0]["previous_rank"] == 3
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_history_manager.py
+++ b/tests/test_history_manager.py
@@ -21,17 +21,17 @@ from src.history_manager import (
 
 class TestHistoryManager(unittest.TestCase):
     """履歴管理機能のテストクラス"""
-    
+
     def setUp(self):
         """各テストの前に実行される"""
         # 一時ファイルを作成
-        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.json')
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix=".json")
         os.close(self.temp_fd)
-        
+
         # パッチを適用
-        self.patcher = patch('src.history_manager.HISTORY_FILE', self.temp_path)
+        self.patcher = patch("src.history_manager.HISTORY_FILE", self.temp_path)
         self.patcher.start()
-        
+
         # サンプルデータ
         self.sample_ranking_data = [
             {
@@ -40,7 +40,7 @@ class TestHistoryManager(unittest.TestCase):
                 "rating": 4.5,
                 "review_count": 100,
                 "price": "¥500",
-                "url": "https://example.com/1"
+                "url": "https://example.com/1",
             },
             {
                 "rank": 2,
@@ -48,19 +48,18 @@ class TestHistoryManager(unittest.TestCase):
                 "rating": 4.0,
                 "review_count": 50,
                 "price": "¥1000",
-                "url": "https://example.com/2"
-            }
+                "url": "https://example.com/2",
+            },
         ]
-    
+
     def tearDown(self):
         """各テストの後に実行される"""
         # パッチを解除
         self.patcher.stop()
-        
+
         # 一時ファイルを削除
         if os.path.exists(self.temp_path):
             os.unlink(self.temp_path)
-
 
     def test_load_empty_history(self):
         """空の履歴を読み込むテスト"""
@@ -69,14 +68,11 @@ class TestHistoryManager(unittest.TestCase):
 
     def test_save_and_load_history(self):
         """履歴の保存と読み込みテスト"""
-        history_data = [{
-            "timestamp": datetime.now().isoformat(),
-            "rankings": self.sample_ranking_data
-        }]
-        
+        history_data = [{"timestamp": datetime.now().isoformat(), "rankings": self.sample_ranking_data}]
+
         save_history(history_data)
         loaded = load_history()
-        
+
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0]["rankings"], self.sample_ranking_data)
 
@@ -85,17 +81,17 @@ class TestHistoryManager(unittest.TestCase):
         # 初回追加
         add_ranking_to_history(self.sample_ranking_data)
         history = load_history()
-        
+
         self.assertEqual(len(history), 1)
         self.assertEqual(history[0]["rankings"], self.sample_ranking_data)
-        
+
         # 2回目追加
         new_data = self.sample_ranking_data.copy()
         new_data[0] = new_data[0].copy()
         new_data[0]["title"] = "新しい書籍"
         add_ranking_to_history(new_data)
         history = load_history()
-        
+
         self.assertEqual(len(history), 2)
         self.assertEqual(history[0]["rankings"][0]["title"], "新しい書籍")  # 最新が先頭
         self.assertEqual(history[1]["rankings"], self.sample_ranking_data)  # 古いデータが後ろ
@@ -108,7 +104,7 @@ class TestHistoryManager(unittest.TestCase):
             data[0] = data[0].copy()
             data[0]["title"] = f"書籍{i}"
             add_ranking_to_history(data)
-        
+
         history = load_history()
         self.assertEqual(len(history), 3)
         self.assertEqual(history[0]["rankings"][0]["title"], "書籍3")  # 最新
@@ -128,13 +124,13 @@ class TestHistoryManager(unittest.TestCase):
         """履歴が複数の場合の前回ランキング取得テスト"""
         # 1回目
         add_ranking_to_history(self.sample_ranking_data)
-        
+
         # 2回目
         new_data = self.sample_ranking_data.copy()
         new_data[0] = new_data[0].copy()
         new_data[0]["title"] = "新しい書籍"
         add_ranking_to_history(new_data)
-        
+
         # 2番目（前回）のデータが返される
         previous = get_previous_rankings()
         self.assertEqual(previous, self.sample_ranking_data)
@@ -146,40 +142,40 @@ class TestHistoryManager(unittest.TestCase):
             {"rank": 2, "title": "書籍D"},  # 新規エントリー
             {"rank": 3, "title": "書籍B"},  # 前回1位から下降
         ]
-        
+
         previous = [
             {"rank": 1, "title": "書籍B"},
             {"rank": 2, "title": "書籍A"},
             {"rank": 3, "title": "書籍C"},  # ランク外へ
         ]
-        
+
         analysis = analyze_ranking_changes(current, previous)
-        
+
         # 新規エントリー
         self.assertEqual(len(analysis["new_entries"]), 1)
         self.assertEqual(analysis["new_entries"][0]["title"], "書籍D")
         self.assertEqual(analysis["new_entries"][0]["rank"], 2)
-        
+
         # ランク変動
         self.assertEqual(len(analysis["rank_changes"]), 2)
-        
+
         # 書籍Aの上昇を確認
         book_a_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍A")
         self.assertEqual(book_a_change["current_rank"], 1)
         self.assertEqual(book_a_change["previous_rank"], 2)
         self.assertEqual(book_a_change["change"], 1)  # 上昇
-        
+
         # 書籍Bの下降を確認
         book_b_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍B")
         self.assertEqual(book_b_change["current_rank"], 3)
         self.assertEqual(book_b_change["previous_rank"], 1)
         self.assertEqual(book_b_change["change"], -2)  # 下降
-        
+
         # ランク外
         self.assertEqual(len(analysis["dropped_out"]), 1)
         self.assertEqual(analysis["dropped_out"][0]["title"], "書籍C")
         self.assertEqual(analysis["dropped_out"][0]["previous_rank"], 3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_history_manager.py
+++ b/tests/test_history_manager.py
@@ -1,0 +1,179 @@
+"""
+履歴管理機能のテスト
+"""
+
+import json
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.history_manager import (
+    add_ranking_to_history,
+    analyze_ranking_changes,
+    get_previous_rankings,
+    load_history,
+    save_history,
+)
+
+
+@pytest.fixture
+def sample_ranking_data():
+    """テスト用のランキングデータ"""
+    return [
+        {
+            "rank": 1,
+            "title": "テスト書籍1",
+            "rating": 4.5,
+            "review_count": 100,
+            "price": "¥500",
+            "url": "https://example.com/1"
+        },
+        {
+            "rank": 2,
+            "title": "テスト書籍2",
+            "rating": 4.0,
+            "review_count": 50,
+            "price": "¥1000",
+            "url": "https://example.com/2"
+        }
+    ]
+
+
+@pytest.fixture
+def temp_history_file():
+    """一時的な履歴ファイルを作成"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        temp_path = f.name
+    
+    # history_manager.HISTORY_FILEをパッチ
+    with patch('src.history_manager.HISTORY_FILE', temp_path):
+        yield temp_path
+    
+    # クリーンアップ
+    Path(temp_path).unlink(missing_ok=True)
+
+
+def test_load_empty_history(temp_history_file):
+    """空の履歴を読み込むテスト"""
+    history = load_history()
+    assert history == []
+
+
+def test_save_and_load_history(temp_history_file, sample_ranking_data):
+    """履歴の保存と読み込みテスト"""
+    history_data = [{
+        "timestamp": datetime.now().isoformat(),
+        "rankings": sample_ranking_data
+    }]
+    
+    save_history(history_data)
+    loaded = load_history()
+    
+    assert len(loaded) == 1
+    assert loaded[0]["rankings"] == sample_ranking_data
+
+
+def test_add_ranking_to_history(temp_history_file, sample_ranking_data):
+    """ランキングを履歴に追加するテスト"""
+    # 初回追加
+    add_ranking_to_history(sample_ranking_data)
+    history = load_history()
+    
+    assert len(history) == 1
+    assert history[0]["rankings"] == sample_ranking_data
+    
+    # 2回目追加
+    new_data = sample_ranking_data.copy()
+    new_data[0]["title"] = "新しい書籍"
+    add_ranking_to_history(new_data)
+    history = load_history()
+    
+    assert len(history) == 2
+    assert history[0]["rankings"][0]["title"] == "新しい書籍"  # 最新が先頭
+    assert history[1]["rankings"] == sample_ranking_data  # 古いデータが後ろ
+
+
+def test_max_history_limit(temp_history_file, sample_ranking_data):
+    """履歴の最大保存数テスト"""
+    # 4回追加（最大3回分なので、最後の3つが残る）
+    for i in range(4):
+        data = sample_ranking_data.copy()
+        data[0]["title"] = f"書籍{i}"
+        add_ranking_to_history(data)
+    
+    history = load_history()
+    assert len(history) == 3
+    assert history[0]["rankings"][0]["title"] == "書籍3"  # 最新
+    assert history[2]["rankings"][0]["title"] == "書籍1"  # 最古（書籍0は削除済み）
+
+
+def test_get_previous_rankings_empty(temp_history_file):
+    """履歴が空の場合の前回ランキング取得テスト"""
+    assert get_previous_rankings() is None
+
+
+def test_get_previous_rankings_single(temp_history_file, sample_ranking_data):
+    """履歴が1つの場合の前回ランキング取得テスト"""
+    add_ranking_to_history(sample_ranking_data)
+    # 初回実行後なので、その履歴を返す
+    assert get_previous_rankings() == sample_ranking_data
+
+
+def test_get_previous_rankings_multiple(temp_history_file, sample_ranking_data):
+    """履歴が複数の場合の前回ランキング取得テスト"""
+    # 1回目
+    add_ranking_to_history(sample_ranking_data)
+    
+    # 2回目
+    new_data = sample_ranking_data.copy()
+    new_data[0]["title"] = "新しい書籍"
+    add_ranking_to_history(new_data)
+    
+    # 2番目（前回）のデータが返される
+    previous = get_previous_rankings()
+    assert previous == sample_ranking_data
+
+
+def test_analyze_ranking_changes():
+    """ランキング変化分析のテスト"""
+    current = [
+        {"rank": 1, "title": "書籍A"},  # 前回2位から上昇
+        {"rank": 2, "title": "書籍D"},  # 新規エントリー
+        {"rank": 3, "title": "書籍B"},  # 前回1位から下降
+    ]
+    
+    previous = [
+        {"rank": 1, "title": "書籍B"},
+        {"rank": 2, "title": "書籍A"},
+        {"rank": 3, "title": "書籍C"},  # ランク外へ
+    ]
+    
+    analysis = analyze_ranking_changes(current, previous)
+    
+    # 新規エントリー
+    assert len(analysis["new_entries"]) == 1
+    assert analysis["new_entries"][0]["title"] == "書籍D"
+    assert analysis["new_entries"][0]["rank"] == 2
+    
+    # ランク変動
+    assert len(analysis["rank_changes"]) == 2
+    
+    # 書籍Aの上昇を確認
+    book_a_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍A")
+    assert book_a_change["current_rank"] == 1
+    assert book_a_change["previous_rank"] == 2
+    assert book_a_change["change"] == 1  # 上昇
+    
+    # 書籍Bの下降を確認
+    book_b_change = next(c for c in analysis["rank_changes"] if c["title"] == "書籍B")
+    assert book_b_change["current_rank"] == 3
+    assert book_b_change["previous_rank"] == 1
+    assert book_b_change["change"] == -2  # 下降
+    
+    # ランク外
+    assert len(analysis["dropped_out"]) == 1
+    assert analysis["dropped_out"][0]["title"] == "書籍C"
+    assert analysis["dropped_out"][0]["previous_rank"] == 3


### PR DESCRIPTION
## Summary
- Gemini APIを使用して前回のランキングとの変化を2-3文で簡潔に要約する機能を追加
- 直近3回分のランキング履歴をJSONファイルに保存し、GitHub Actionsで自動コミット
- 新規ランクイン、順位変動、ランク外への変化を検出して分析

## Changes
- `history_manager.py`: ランキング履歴の保存・読み込み・変化分析機能を実装
- `summarizer.py`: 変化分析用と初回実行用の要約生成関数を追加
- `scraper.py`: 構造化データも返す関数を追加
- `main.py`: 履歴管理と変化分析を統合
- GitHub Actions: 実行後に履歴ファイルをmainブランチに自動コミット
- テスト追加とREADME更新

## Test plan
- [x] ユニットテストの追加（履歴管理機能）
- [ ] ローカル環境での動作確認
- [ ] GitHub Actionsでの履歴ファイル自動コミットの確認

🤖 Generated with [Claude Code](https://claude.ai/code)