### PR TITLE
[chore]Python 3.13への更新とREADMEの最新化

### DIFF
--- a/.github/workflows/daily-ranking.yml
+++ b/.github/workflows/daily-ranking.yml
@@ -24,8 +24,8 @@ jobs:
         version: "latest"
         enable-cache: true
 
-    - name: Python 3.12をセットアップ
-      run: uv python install 3.12
+    - name: Python 3.13をセットアップ
+      run: uv python install 3.13
 
     - name: 依存パッケージをインストール
       run: uv sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
         version: "latest"
         enable-cache: true
     
-    - name: Python 3.12をセットアップ
-      run: uv python install 3.12
+    - name: Python 3.13をセットアップ
+      run: uv python install 3.13
     
     - name: 依存パッケージをインストール
       run: uv sync
@@ -52,8 +52,8 @@ jobs:
         version: "latest"
         enable-cache: true
     
-    - name: Python 3.12をセットアップ
-      run: uv python install 3.12
+    - name: Python 3.13をセットアップ
+      run: uv python install 3.13
     
     - name: 依存パッケージをインストール
       run: uv sync

--- a/README.md
+++ b/README.md
@@ -2,26 +2,46 @@
 
 ## 概要
 Amazonの「Kindle電子書籍売れ筋ランキング」の上位10タイトルを毎日スクレイピングし、LINEで通知するbotです。
-GitHub Actionsを使用して、毎日朝6時に自動実行されます。
+GitHub Actionsを使用して、毎日正午12時（日本時間）に自動実行されます。
 
 ## 機能
 - Amazonの「Kindle本の売れ筋ランキング」から上位10タイトルをスクレイピング
   - https://www.amazon.co.jp/gp/bestsellers/digital-text/2275256051
 - スクレイピングしたデータをLINE Messaging APIを使ってLINEに通知
-- GitHub Actionsによる定期実行（毎日午前6時）
+- GitHub Actionsによる定期実行（毎日正午12時）
 - **Gemini APIによるランキング変化の要約機能**
   - 前回のランキングと比較して変化を分析
   - 新規ランクイン、順位変動、ランク外などを2-3文で簡潔にレポート
   - 履歴は直近3回分を保存
 
 ### 通知例
+
+#### Gemini要約付きの場合
+```
+📊 注目の変化：「〇〇」が初ランクイン2位！「△△」は5位から1位に急上昇。ビジネス書が好調です。
+
+---
+
 1位|タイトル
 ⭐️4.5(123件)
 ¥1,000
 https://www.amazon.co.jp/dp/XXXXXXXXXX
 
+（以下、ランキング続く）
+```
+
+#### 通常の場合（Gemini無効時）
+```
+1位|タイトル
+⭐️4.5(123件)
+¥1,000
+https://www.amazon.co.jp/dp/XXXXXXXXXX
+
+（以下、ランキング続く）
+```
+
 ## 技術スタック
-- Python 3.12+
+- Python 3.13+
 - [uv](https://github.com/astral-sh/uv) (Fast Python package manager)
 - BeautifulSoup4（スクレイピング）
 - LINE Messaging API（通知）
@@ -86,14 +106,15 @@ uv run python run_tests.py --all
 uv run python run_tests.py -a
 ```
 
-### 従来の方法（pip使用）
-uvが利用できない環境では、pipでも実行可能です：
-```bash
-# pyproject.tomlから依存関係をインストール
-pip install -e .
+### 本番環境での実行
 
-# テストの実行
-python run_tests.py --quick
+```bash
+# 環境変数を設定してから実行
+export LINE_CHANNEL_ACCESS_TOKEN="your_token"
+export LINE_USER_ID="your_user_id"
+export GEMINI_API_KEY="your_api_key"  # オプション
+
+uv run python src/main.py
 ```
 
 ### GitHub Actionsでのテスト

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ uv run python src/main.py
 プッシュまたはプルリクエスト時に自動的にテストが実行されます。
 手動でテストを実行したい場合は、GitHubのActionsタブから「スクレイピングテスト」ワークフローを手動実行できます。
 
-### テスト内容
+#### テスト内容
 
 1. **基本的なスクレイピングテスト**: 実際にAmazonから3件のデータを取得
 2. **limitパラメータテスト**: 指定した件数が正しく取得できるか確認
@@ -130,3 +130,26 @@ uv run python src/main.py
 4. **リトライ機能テスト**: エラー時のリトライが正しく動作するか確認
 5. **エラーハンドリングテスト**: エラー時に適切なメッセージが表示されるか確認
 6. **パフォーマンステスト**: 処理時間が適切な範囲内か確認
+7. **履歴管理機能テスト**: ランキング履歴の保存・読み込み・変化分析のテスト
+
+## プロジェクト構成
+
+```
+kindle-rank-bot/
+├── src/
+│   ├── main.py              # メインエントリーポイント
+│   ├── scraper.py           # Amazonスクレイピング機能
+│   ├── notifier.py          # LINE通知機能
+│   ├── summarizer.py        # Gemini要約機能
+│   ├── history_manager.py   # ランキング履歴管理
+│   └── config.py            # 設定管理
+├── tests/
+│   ├── test_scraper.py      # スクレイピングのテスト
+│   └── test_history_manager.py # 履歴管理のテスト
+├── .github/workflows/
+│   ├── daily-ranking.yml    # 毎日12時の定期実行
+│   └── test.yml             # テスト自動実行
+├── pyproject.toml           # プロジェクト設定
+├── uv.lock                  # 依存関係ロックファイル
+└── ranking_history.json     # ランキング履歴（自動生成）
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Kindle売れ筋ランキング通知Bot - A Python bot that scrapes Amazon's Kindle bestseller rankings and sends daily notifications via LINE"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 authors = [
     { name = "naoto714714", email = "naoto714714@users.noreply.github.com" }
 ]
@@ -13,10 +13,6 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 
@@ -39,7 +35,7 @@ dev-dependencies = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py313"
 line-length = 120
 src = ["src", "tests"]
 

--- a/src/history_manager.py
+++ b/src/history_manager.py
@@ -7,7 +7,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ HISTORY_FILE = "ranking_history.json"
 MAX_HISTORY_COUNT = 3
 
 
-def load_history() -> List[Dict]:
+def load_history() -> list[dict]:
     """
     履歴ファイルからランキング履歴を読み込む
 
@@ -29,7 +29,7 @@ def load_history() -> List[Dict]:
         return []
 
     try:
-        with open(history_path, "r", encoding="utf-8") as f:
+        with open(history_path, encoding="utf-8") as f:
             data = json.load(f)
             return data.get("history", [])
     except Exception as e:
@@ -37,7 +37,7 @@ def load_history() -> List[Dict]:
         return []
 
 
-def save_history(history: List[Dict]) -> None:
+def save_history(history: list[dict]) -> None:
     """
     履歴データをファイルに保存
 
@@ -53,7 +53,7 @@ def save_history(history: List[Dict]) -> None:
         raise
 
 
-def add_ranking_to_history(ranking_data: List[Dict]) -> None:
+def add_ranking_to_history(ranking_data: list[dict]) -> None:
     """
     新しいランキングデータを履歴に追加
 
@@ -75,7 +75,7 @@ def add_ranking_to_history(ranking_data: List[Dict]) -> None:
     save_history(history)
 
 
-def get_previous_rankings() -> Optional[List[Dict]]:
+def get_previous_rankings() -> Optional[list[dict]]:
     """
     直前のランキングデータを取得
 
@@ -94,7 +94,7 @@ def get_previous_rankings() -> Optional[List[Dict]]:
         return None
 
 
-def analyze_ranking_changes(current: List[Dict], previous: List[Dict]) -> Dict:
+def analyze_ranking_changes(current: list[dict], previous: list[dict]) -> dict:
     """
     現在と過去のランキングを比較して変化を分析
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -2,7 +2,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -60,7 +60,7 @@ def _fetch_amazon_page(max_retries: int = None) -> BeautifulSoup:
             return BeautifulSoup(response.content, "html.parser")
         except requests.exceptions.RequestException as e:
             if attempt == max_retries - 1:
-                raise Exception(f"スクレイピングに失敗しました（{max_retries}回試行）: {str(e)}")
+                raise Exception(f"スクレイピングに失敗しました（{max_retries}回試行）: {str(e)}") from e
 
             # 指数バックオフ（1秒、2秒、4秒...）
             wait_time = 2**attempt
@@ -123,7 +123,7 @@ def _parse_book_item(item, rank: int) -> Optional[KindleBook]:
         return None
 
 
-def _parse_books_from_soup(soup: BeautifulSoup, limit: int) -> List[KindleBook]:
+def _parse_books_from_soup(soup: BeautifulSoup, limit: int) -> list[KindleBook]:
     """BeautifulSoupオブジェクトから書籍リストを抽出"""
     items = soup.find_all("div", {"class": "_cDEzb_grid-cell_1uMOS"}, limit=limit)
 
@@ -155,7 +155,7 @@ def get_amazon_kindle_ranking(limit=10, max_retries=3) -> str:
     return "\n\n".join(result_lines)
 
 
-def get_amazon_kindle_ranking_with_data(limit=10, max_retries=3) -> tuple[str, List[dict]]:
+def get_amazon_kindle_ranking_with_data(limit=10, max_retries=3) -> tuple[str, list[dict]]:
     """
     Amazonの Kindle ランキングを取得して文字列と構造化データの両方を返す
 

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -3,7 +3,7 @@ Gemini APIを使用してKindleランキングデータの要約を生成する�
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 from google import genai
 from google.genai import errors as genai_errors
@@ -90,7 +90,7 @@ def _call_gemini_api(prompt: str, system_instruction: str) -> str:
     return response.text.strip()
 
 
-def generate_ranking_changes_summary(changes_analysis: Dict, current_ranking_text: str) -> Optional[str]:
+def generate_ranking_changes_summary(changes_analysis: dict, current_ranking_text: str) -> Optional[str]:
     """
     Gemini APIを使ってランキングの変化を要約
 
@@ -168,7 +168,7 @@ def generate_first_ranking_summary(ranking_text: str) -> Optional[str]:
         return None
 
 
-def _format_changes_for_prompt(analysis: Dict) -> str:
+def _format_changes_for_prompt(analysis: dict) -> str:
     """
     変化分析結果をプロンプト用のテキストに整形
     """


### PR DESCRIPTION
## Summary
- PythonバージョンをPython 3.13（最新安定版）に更新
- READMEの古い情報を最新版に更新し、見やすさを改善

## Changes
### Python 3.13へのアップデート
- pyproject.tomlでPython 3.13を最小要件に設定
- GitHub ActionsでPython 3.13を使用
- 非推奨の型アノテーション（typing.List/Dict）を修正

### README更新
- 実行時間を6時→12時に修正
- pip使用方法を削除（uvのみサポート）
- 通知例にGemini要約付きの例を追加
- プロジェクト構成図を追加
- テスト項目に履歴管理機能を追加

## Test plan
- [x] 履歴管理テストが正常に動作
- [ ] GitHub ActionsでPython 3.13での動作確認
- [ ] スクレイピングテストの実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)