### PR TITLE
[feat] LINEからDiscord WebHookに変更

### DIFF
--- a/.github/workflows/daily-ranking.yml
+++ b/.github/workflows/daily-ranking.yml
@@ -32,8 +32,7 @@ jobs:
 
     - name: Kindleランキング通知を実行
       env:
-        LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
-        LINE_USER_ID: ${{ secrets.LINE_USER_ID }}
+        DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: uv run python src/main.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - レビューが完了したら、プルリクエストに日本語でコメントとして投稿してください
 
 ## Project Overview
-Kindle売れ筋ランキング通知Bot - A Python bot that scrapes Amazon's Kindle bestseller rankings and sends daily notifications via LINE. The bot runs automatically every day at 12:00 JST using GitHub Actions.
+Kindle売れ筋ランキング通知Bot - A Python bot that scrapes Amazon's Kindle bestseller rankings and sends daily notifications via Discord WebHook. The bot runs automatically every day at 12:00 JST using GitHub Actions.
 
 ## Common Commands
 
@@ -99,8 +99,7 @@ python run_tests.py --quick
 
 ### Environment Variables
 Required for local development:
-- `LINE_CHANNEL_ACCESS_TOKEN`: LINE Messaging APIのアクセストークン
-- `LINE_USER_ID`: 送信先のLINEユーザーID
+- `DISCORD_WEBHOOK_URL`: Discord WebHookのURL
 
 Optional:
 - `KINDLE_RANKING_LIMIT`: 取得するランキング件数（デフォルト: 10）
@@ -120,7 +119,7 @@ Optional:
    - Extracts title, rating, review count, price, and product URL
    - Retry mechanism with exponential backoff (max 3 attempts)
    - Handles missing data gracefully (ratings, prices, URLs)
-3. **src/notifier.py**: Sends messages via LINE Messaging API
+3. **src/notifier.py**: Sends messages via Discord WebHook API
    - Environment variable validation
    - Detailed error messages for API failures
 4. **src/summarizer.py**: Gemini API integration for AI-powered summaries

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Kindle売れ筋ランキング通知Bot
 
 ## 概要
-Amazonの「Kindle電子書籍売れ筋ランキング」の上位10タイトルを毎日スクレイピングし、LINEで通知するbotです。
+Amazonの「Kindle電子書籍売れ筋ランキング」の上位10タイトルを毎日スクレイピングし、Discord WebHookで通知するbotです。
 GitHub Actionsを使用して、毎日正午12時（日本時間）に自動実行されます。
 
 ## 機能
 - Amazonの「Kindle本の売れ筋ランキング」から上位10タイトルをスクレイピング
   - https://www.amazon.co.jp/gp/bestsellers/digital-text/2275256051
-- スクレイピングしたデータをLINE Messaging APIを使ってLINEに通知
+- スクレイピングしたデータをDiscord WebHookを使ってDiscordに通知
 - GitHub Actionsによる定期実行（毎日正午12時）
 - **Gemini APIによるランキング変化の要約機能**
   - 前回のランキングと比較して変化を分析
@@ -44,15 +44,14 @@ https://www.amazon.co.jp/dp/XXXXXXXXXX
 - Python 3.13+
 - [uv](https://github.com/astral-sh/uv) (Fast Python package manager)
 - BeautifulSoup4（スクレイピング）
-- LINE Messaging API（通知）
+- Discord WebHook API（通知）
 - GitHub Actions（定期実行）
 
 ## 環境変数
 GitHub Secretsまたはローカルの.envファイルに以下の環境変数を設定してください：
 
 ### 必須
-- `LINE_CHANNEL_ACCESS_TOKEN`: LINE Messaging APIのアクセストークン
-- `LINE_USER_ID`: 送信先のLINEユーザーID
+- `DISCORD_WEBHOOK_URL`: Discord WebHookのURL
 
 ### オプション
 - `KINDLE_RANKING_LIMIT`: 取得するランキング件数（デフォルト: 10）
@@ -110,8 +109,7 @@ uv run python run_tests.py -a
 
 ```bash
 # 環境変数を設定してから実行
-export LINE_CHANNEL_ACCESS_TOKEN="your_token"
-export LINE_USER_ID="your_user_id"
+export DISCORD_WEBHOOK_URL="your_webhook_url"
 export GEMINI_API_KEY="your_api_key"  # オプション
 
 uv run python src/main.py
@@ -139,7 +137,7 @@ kindle-rank-bot/
 ├── src/
 │   ├── main.py              # メインエントリーポイント
 │   ├── scraper.py           # Amazonスクレイピング機能
-│   ├── notifier.py          # LINE通知機能
+│   ├── notifier.py          # Discord WebHook通知機能
 │   ├── summarizer.py        # Gemini要約機能
 │   ├── history_manager.py   # ランキング履歴管理
 │   └── config.py            # 設定管理

--- a/src/config.py
+++ b/src/config.py
@@ -18,10 +18,8 @@ class Config:
     request_timeout: int = 10
     max_retries: int = 3
 
-    # LINE API 設定
-    line_api_url: str = "https://api.line.me/v2/bot/message/push"
-    line_channel_access_token: str = ""
-    line_user_id: str = ""
+    # Discord WebHook 設定
+    discord_webhook_url: str = ""
 
     # Gemini API 設定
     gemini_api_key: str = ""
@@ -37,8 +35,7 @@ class Config:
         """環境変数から設定を読み込む"""
         return cls(
             kindle_ranking_limit=int(os.getenv("KINDLE_RANKING_LIMIT", "10")),
-            line_channel_access_token=os.getenv("LINE_CHANNEL_ACCESS_TOKEN", ""),
-            line_user_id=os.getenv("LINE_USER_ID", ""),
+            discord_webhook_url=os.getenv("DISCORD_WEBHOOK_URL", ""),
             gemini_api_key=os.getenv("GEMINI_API_KEY", ""),
             enable_gemini_summary=os.getenv("ENABLE_GEMINI_SUMMARY", "true").lower() == "true",
             log_level=os.getenv("LOG_LEVEL", "INFO"),
@@ -46,10 +43,8 @@ class Config:
 
     def validate(self) -> None:
         """設定の妥当性を検証"""
-        if not self.line_channel_access_token:
-            raise ValueError("環境変数 LINE_CHANNEL_ACCESS_TOKEN が設定されていません")
-        if not self.line_user_id:
-            raise ValueError("環境変数 LINE_USER_ID が設定されていません")
+        if not self.discord_webhook_url:
+            raise ValueError("環境変数 DISCORD_WEBHOOK_URL が設定されていません")
         if self.kindle_ranking_limit <= 0:
             raise ValueError("KINDLE_RANKING_LIMIT は1以上である必要があります")
         if self.enable_gemini_summary and not self.gemini_api_key:

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from history_manager import (
     analyze_ranking_changes,
     get_previous_rankings,
 )
-from notifier import send_line_message
+from notifier import send_discord_message
 from scraper import get_amazon_kindle_ranking_with_data
 from summarizer import (
     format_message_with_summary,
@@ -67,9 +67,9 @@ def main():
         final_message = format_message_with_summary(ranking_text, summary)
         logger.info(f"最終メッセージ作成完了: {len(final_message)}文字")
 
-        # LINEに送信
-        logger.info("LINEへの送信を開始します...")
-        send_line_message(final_message)
+        # Discordに送信
+        logger.info("Discordへの送信を開始します...")
+        send_discord_message(final_message)
         logger.info("処理が正常に完了しました")
 
     except Exception as e:

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -8,34 +8,29 @@ from config import config
 logger = logging.getLogger(__name__)
 
 
-def send_line_message(message: str) -> None:
-    # ヘッダーにアクセストークンを設定
+def send_discord_message(message: str) -> None:
+    # ヘッダーを設定
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {config.line_channel_access_token}",
     }
 
-    # 送信するデータ（メッセージ内容と送信先ID）
-    payload = {"to": config.line_user_id, "messages": [{"type": "text", "text": message}]}
+    # 送信するデータ（メッセージ内容）
+    payload = {"content": message}
 
     try:
         # POSTリクエストを送信
         response = requests.post(
-            config.line_api_url, headers=headers, data=json.dumps(payload), timeout=config.request_timeout
+            config.discord_webhook_url, headers=headers, data=json.dumps(payload), timeout=config.request_timeout
         )
 
         # 結果を表示
-        if response.status_code == 200:
-            logger.info("LINEメッセージが正常に送信されました")
+        if response.status_code == 204:
+            logger.info("Discordメッセージが正常に送信されました")
         else:
-            error_msg = f"LINE APIエラー: ステータスコード={response.status_code}"
+            error_msg = f"Discord WebHook APIエラー: ステータスコード={response.status_code}"
             if response.text:
-                try:
-                    error_detail = json.loads(response.text)
-                    error_msg += f", エラー詳細={error_detail}"
-                except (json.JSONDecodeError, ValueError):
-                    error_msg += f", レスポンス={response.text}"
+                error_msg += f", レスポンス={response.text}"
             raise Exception(error_msg)
 
     except requests.exceptions.RequestException as e:
-        raise Exception(f"LINE APIへの接続エラー: {str(e)}")
+        raise Exception(f"Discord WebHook APIへの接続エラー: {str(e)}")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -19,7 +19,7 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         mock_response = Mock()
         mock_response.status_code = 204
         mock_post.return_value = mock_response
@@ -33,7 +33,7 @@ class TestNotifier(unittest.TestCase):
             "https://discord.com/api/webhooks/test",
             headers={"Content-Type": "application/json"},
             data=json.dumps({"content": test_message}),
-            timeout=10
+            timeout=10,
         )
 
     @patch("src.notifier.requests.post")
@@ -43,7 +43,7 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         mock_response = Mock()
         mock_response.status_code = 400
         mock_response.text = "Bad Request"
@@ -64,8 +64,9 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         import requests
+
         mock_post.side_effect = requests.exceptions.ConnectionError("接続失敗")
 
         # テスト実行とアサーション
@@ -82,8 +83,9 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         import requests
+
         mock_post.side_effect = requests.exceptions.Timeout("タイムアウト")
 
         # テスト実行とアサーション

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,98 @@
+"""
+Discord WebHook通知機能のテスト
+"""
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from src.notifier import send_discord_message
+
+
+class TestNotifier(unittest.TestCase):
+    """Discord WebHook通知機能のテストクラス"""
+
+    @patch("src.notifier.requests.post")
+    @patch("src.notifier.config")
+    def test_send_discord_message_success(self, mock_config, mock_post):
+        """Discord WebHookメッセージ送信成功のテスト"""
+        # モック設定
+        mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
+        mock_config.request_timeout = 10
+        
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_post.return_value = mock_response
+
+        # テスト実行
+        test_message = "テストメッセージ"
+        send_discord_message(test_message)
+
+        # アサーション
+        mock_post.assert_called_once_with(
+            "https://discord.com/api/webhooks/test",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"content": test_message}),
+            timeout=10
+        )
+
+    @patch("src.notifier.requests.post")
+    @patch("src.notifier.config")
+    def test_send_discord_message_api_error(self, mock_config, mock_post):
+        """Discord WebHook APIエラーのテスト"""
+        # モック設定
+        mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
+        mock_config.request_timeout = 10
+        
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        mock_post.return_value = mock_response
+
+        # テスト実行とアサーション
+        with self.assertRaises(Exception) as context:
+            send_discord_message("テストメッセージ")
+
+        self.assertIn("Discord WebHook APIエラー", str(context.exception))
+        self.assertIn("ステータスコード=400", str(context.exception))
+        self.assertIn("Bad Request", str(context.exception))
+
+    @patch("src.notifier.requests.post")
+    @patch("src.notifier.config")
+    def test_send_discord_message_connection_error(self, mock_config, mock_post):
+        """Discord WebHook接続エラーのテスト"""
+        # モック設定
+        mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
+        mock_config.request_timeout = 10
+        
+        import requests
+        mock_post.side_effect = requests.exceptions.ConnectionError("接続失敗")
+
+        # テスト実行とアサーション
+        with self.assertRaises(Exception) as context:
+            send_discord_message("テストメッセージ")
+
+        self.assertIn("Discord WebHook APIへの接続エラー", str(context.exception))
+        self.assertIn("接続失敗", str(context.exception))
+
+    @patch("src.notifier.requests.post")
+    @patch("src.notifier.config")
+    def test_send_discord_message_timeout(self, mock_config, mock_post):
+        """Discord WebHookタイムアウトのテスト"""
+        # モック設定
+        mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
+        mock_config.request_timeout = 10
+        
+        import requests
+        mock_post.side_effect = requests.exceptions.Timeout("タイムアウト")
+
+        # テスト実行とアサーション
+        with self.assertRaises(Exception) as context:
+            send_discord_message("テストメッセージ")
+
+        self.assertIn("Discord WebHook APIへの接続エラー", str(context.exception))
+        self.assertIn("タイムアウト", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 通知方法をLINE Messaging APIからDiscord WebHookに変更
- 環境変数を`DISCORD_WEBHOOK_URL`に統一
- 関連するドキュメントとテストをすべて更新

## Test plan
- [ ] Discord WebHookのテスト実行
- [ ] GitHub Actionsでの動作確認  
- [ ] ドキュメントの内容確認

🤖 Generated with [Claude Code](https://claude.ai/code)