### PR TITLE
[feat] Discord WebHookメッセージ分割機能を実装

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from history_manager import (
     analyze_ranking_changes,
     get_previous_rankings,
 )
-from notifier import send_discord_message
+from notifier import send_discord_message_with_thread
 from scraper import get_amazon_kindle_ranking_with_data
 from summarizer import (
     format_message_with_summary,
@@ -63,13 +63,9 @@ def main():
         add_ranking_to_history(ranking_data)
         logger.info("ランキングデータを履歴に保存しました")
 
-        # ランキングと要約を組み合わせて最終メッセージを作成
-        final_message = format_message_with_summary(ranking_text, summary)
-        logger.info(f"最終メッセージ作成完了: {len(final_message)}文字")
-
-        # Discordに送信
+        # Discordに送信（要約をメインメッセージ、ランキングをスレッドに分けて送信）
         logger.info("Discordへの送信を開始します...")
-        send_discord_message(final_message)
+        send_discord_message_with_thread(summary, ranking_text)
         logger.info("処理が正常に完了しました")
 
     except Exception as e:

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) -> None:
     """
-    Discordに要約をメインメッセージとして送信し、ランキングをスレッドとして送信
+    Discordに要約をメインメッセージとして送信し、ランキングを続けて送信
     
     Args:
         summary: Gemini生成の要約（Noneの場合は代替メッセージ）
@@ -26,8 +26,7 @@ def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) 
         # 1. メインメッセージ（要約）を送信
         main_message = summary if summary else "📊 本日のKindle売れ筋ランキングを取得しました"
         main_payload = {
-            "content": main_message,
-            "wait": True  # レスポンスでメッセージ情報を取得するため
+            "content": main_message
         }
         
         logger.info("Discordにメインメッセージ（要約）を送信中...")
@@ -44,43 +43,29 @@ def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) 
                 error_msg += f", レスポンス={main_response.text}"
             raise Exception(error_msg)
         
-        # メッセージIDを取得
-        try:
-            main_message_data = main_response.json()
-            message_id = main_message_data.get("id")
-        except (ValueError, KeyError) as e:
-            raise Exception(f"メインメッセージのレスポンス解析エラー: {str(e)}, レスポンス: {main_response.text}")
+        logger.info("メインメッセージ送信成功")
         
-        if not message_id:
-            raise Exception("メインメッセージのIDを取得できませんでした")
-        
-        logger.info(f"メインメッセージ送信成功（ID: {message_id}）")
-        
-        # 2. スレッドとしてランキングを送信
-        # Discord WebHookではthread_idパラメータを使ってスレッド返信を作成
-        thread_payload = {
-            "content": f"```\n{ranking_text}\n```"
+        # 2. ランキング詳細を続けて送信（コードブロック形式）
+        ranking_payload = {
+            "content": f"**📚 詳細ランキング**\n```\n{ranking_text}\n```"
         }
         
-        # スレッド作成のためのURL（メッセージIDをパスに含める）
-        thread_url = f"{config.discord_webhook_url}?thread_id={message_id}"
-        
-        logger.info("Discordにランキング詳細をスレッドとして送信中...")
-        thread_response = requests.post(
-            thread_url,
+        logger.info("Discordにランキング詳細を送信中...")
+        ranking_response = requests.post(
+            config.discord_webhook_url,
             headers=headers,
-            data=json.dumps(thread_payload),
+            data=json.dumps(ranking_payload),
             timeout=config.request_timeout
         )
         
-        if thread_response.status_code not in (200, 204):
-            error_msg = f"Discord WebHook APIエラー（スレッド）: ステータスコード={thread_response.status_code}"
-            if thread_response.text:
-                error_msg += f", レスポンス={thread_response.text}"
+        if ranking_response.status_code not in (200, 204):
+            error_msg = f"Discord WebHook APIエラー（ランキング）: ステータスコード={ranking_response.status_code}"
+            if ranking_response.text:
+                error_msg += f", レスポンス={ranking_response.text}"
             raise Exception(error_msg)
         
-        logger.info("スレッドメッセージ送信成功")
-        logger.info("Discordメッセージが正常に送信されました（メイン + スレッド）")
+        logger.info("ランキングメッセージ送信成功")
+        logger.info("Discordメッセージが正常に送信されました（要約 + ランキング）")
         
     except requests.exceptions.RequestException as e:
         raise Exception(f"Discord WebHook APIへの接続エラー: {str(e)}")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional
 
 import requests
 
@@ -8,22 +9,92 @@ from config import config
 logger = logging.getLogger(__name__)
 
 
-def send_discord_message(message: str) -> None:
+def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) -> None:
+    """
+    Discordに要約をメインメッセージとして送信し、ランキングをスレッドとして送信
+    
+    Args:
+        summary: Gemini生成の要約（Noneの場合は代替メッセージ）
+        ranking_text: ランキングテキスト
+    """
     # ヘッダーを設定
     headers = {
         "Content-Type": "application/json",
     }
+    
+    try:
+        # 1. メインメッセージ（要約）を送信
+        main_message = summary if summary else "📊 本日のKindle売れ筋ランキングを取得しました"
+        main_payload = {
+            "content": main_message,
+            "wait": True  # レスポンスでメッセージ情報を取得するため
+        }
+        
+        logger.info("Discordにメインメッセージ（要約）を送信中...")
+        main_response = requests.post(
+            config.discord_webhook_url, 
+            headers=headers, 
+            data=json.dumps(main_payload), 
+            timeout=config.request_timeout
+        )
+        
+        if main_response.status_code not in (200, 204):
+            error_msg = f"Discord WebHook APIエラー（メインメッセージ）: ステータスコード={main_response.status_code}"
+            if main_response.text:
+                error_msg += f", レスポンス={main_response.text}"
+            raise Exception(error_msg)
+        
+        # メッセージIDを取得
+        main_message_data = main_response.json()
+        message_id = main_message_data.get("id")
+        
+        if not message_id:
+            raise Exception("メインメッセージのIDを取得できませんでした")
+        
+        logger.info(f"メインメッセージ送信成功（ID: {message_id}）")
+        
+        # 2. スレッドとしてランキングを送信
+        thread_payload = {
+            "content": f"```\n{ranking_text}\n```",
+            "thread_id": message_id
+        }
+        
+        logger.info("Discordにランキング詳細をスレッドとして送信中...")
+        thread_response = requests.post(
+            config.discord_webhook_url,
+            headers=headers,
+            data=json.dumps(thread_payload),
+            timeout=config.request_timeout
+        )
+        
+        if thread_response.status_code not in (200, 204):
+            error_msg = f"Discord WebHook APIエラー（スレッド）: ステータスコード={thread_response.status_code}"
+            if thread_response.text:
+                error_msg += f", レスポンス={thread_response.text}"
+            raise Exception(error_msg)
+        
+        logger.info("スレッドメッセージ送信成功")
+        logger.info("Discordメッセージが正常に送信されました（メイン + スレッド）")
+        
+    except requests.exceptions.RequestException as e:
+        raise Exception(f"Discord WebHook APIへの接続エラー: {str(e)}")
 
-    # 送信するデータ（メッセージ内容）
+
+def send_discord_message(message: str) -> None:
+    """
+    後方互換性のため残しておく単純なメッセージ送信関数
+    """
+    headers = {
+        "Content-Type": "application/json",
+    }
+
     payload = {"content": message}
 
     try:
-        # POSTリクエストを送信
         response = requests.post(
             config.discord_webhook_url, headers=headers, data=json.dumps(payload), timeout=config.request_timeout
         )
 
-        # 結果を表示
         if response.status_code in (200, 204):
             logger.info("Discordメッセージが正常に送信されました")
         else:

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) -> None:
     """
     Discordに要約をメインメッセージとして送信し、ランキングを続けて送信
-    
+
     Args:
         summary: Gemini生成の要約（Noneの場合は代替メッセージ）
         ranking_text: ランキングテキスト
@@ -21,52 +21,45 @@ def send_discord_message_with_thread(summary: Optional[str], ranking_text: str) 
     headers = {
         "Content-Type": "application/json",
     }
-    
+
     try:
         # 1. メインメッセージ（要約）を送信
         main_message = summary if summary else "📊 本日のKindle売れ筋ランキングを取得しました"
-        main_payload = {
-            "content": main_message
-        }
-        
+        main_payload = {"content": main_message}
+
         logger.info("Discordにメインメッセージ（要約）を送信中...")
         main_response = requests.post(
-            config.discord_webhook_url, 
-            headers=headers, 
-            data=json.dumps(main_payload), 
-            timeout=config.request_timeout
+            config.discord_webhook_url, headers=headers, data=json.dumps(main_payload), timeout=config.request_timeout
         )
-        
+
         if main_response.status_code not in (200, 204):
             error_msg = f"Discord WebHook APIエラー（メインメッセージ）: ステータスコード={main_response.status_code}"
             if main_response.text:
                 error_msg += f", レスポンス={main_response.text}"
             raise Exception(error_msg)
-        
+
         logger.info("メインメッセージ送信成功")
-        
+
         # 2. ランキング詳細を続けて送信（コードブロック形式）
-        ranking_payload = {
-            "content": f"**📚 詳細ランキング**\n```\n{ranking_text}\n```"
-        }
-        
+        ranking_payload = {"content": f"**📚 詳細ランキング**\n```\n{ranking_text}\n```"}
+
         logger.info("Discordにランキング詳細を送信中...")
         ranking_response = requests.post(
             config.discord_webhook_url,
             headers=headers,
             data=json.dumps(ranking_payload),
-            timeout=config.request_timeout
+            timeout=config.request_timeout,
         )
-        
+
         if ranking_response.status_code not in (200, 204):
             error_msg = f"Discord WebHook APIエラー（ランキング）: ステータスコード={ranking_response.status_code}"
             if ranking_response.text:
                 error_msg += f", レスポンス={ranking_response.text}"
             raise Exception(error_msg)
-        
+
         logger.info("ランキングメッセージ送信成功")
         logger.info("Discordメッセージが正常に送信されました（要約 + ランキング）")
-        
+
     except requests.exceptions.RequestException as e:
         raise Exception(f"Discord WebHook APIへの接続エラー: {str(e)}")
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -127,7 +127,7 @@ class TestNotifier(unittest.TestCase):
     @patch("notifier.requests.post")
     @patch("notifier.config")
     def test_send_discord_message_with_thread_success(self, mock_config, mock_post):
-        """Discord WebHookスレッドメッセージ送信成功のテスト"""
+        """Discord WebHook分割メッセージ送信成功のテスト"""
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
@@ -135,14 +135,13 @@ class TestNotifier(unittest.TestCase):
         # メインメッセージのレスポンス
         main_response = Mock()
         main_response.status_code = 200
-        main_response.json.return_value = {"id": "123456789"}
         
-        # スレッドメッセージのレスポンス
-        thread_response = Mock()
-        thread_response.status_code = 200
+        # ランキングメッセージのレスポンス
+        ranking_response = Mock()
+        ranking_response.status_code = 200
         
         # リクエストの順番に応じてレスポンスを返す
-        mock_post.side_effect = [main_response, thread_response]
+        mock_post.side_effect = [main_response, ranking_response]
 
         # テスト実行
         test_summary = "テスト要約"
@@ -157,14 +156,13 @@ class TestNotifier(unittest.TestCase):
         self.assertEqual(first_call[0][0], "https://discord.com/api/webhooks/test")
         first_payload = json.loads(first_call[1]["data"])
         self.assertEqual(first_payload["content"], test_summary)
-        self.assertTrue(first_payload["wait"])
         
-        # 2回目（スレッド）の呼び出しを確認
+        # 2回目（ランキング）の呼び出しを確認
         second_call = mock_post.call_args_list[1]
         self.assertEqual(second_call[0][0], "https://discord.com/api/webhooks/test")
         second_payload = json.loads(second_call[1]["data"])
         self.assertIn(test_ranking, second_payload["content"])
-        self.assertEqual(second_payload["thread_id"], "123456789")
+        self.assertIn("詳細ランキング", second_payload["content"])
 
     @patch("notifier.requests.post")
     @patch("notifier.config")
@@ -190,7 +188,7 @@ class TestNotifier(unittest.TestCase):
     @patch("notifier.requests.post")
     @patch("notifier.config")
     def test_send_discord_message_with_thread_no_summary(self, mock_config, mock_post):
-        """Discord WebHookスレッドメッセージ（要約なし）のテスト"""
+        """Discord WebHook分割メッセージ（要約なし）のテスト"""
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
@@ -198,13 +196,12 @@ class TestNotifier(unittest.TestCase):
         # メインメッセージのレスポンス
         main_response = Mock()
         main_response.status_code = 200
-        main_response.json.return_value = {"id": "123456789"}
         
-        # スレッドメッセージのレスポンス
-        thread_response = Mock()
-        thread_response.status_code = 200
+        # ランキングメッセージのレスポンス
+        ranking_response = Mock()
+        ranking_response.status_code = 200
         
-        mock_post.side_effect = [main_response, thread_response]
+        mock_post.side_effect = [main_response, ranking_response]
 
         # テスト実行（要約なし）
         send_discord_message_with_thread(None, "テストランキング")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -131,15 +131,15 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         # メインメッセージのレスポンス
         main_response = Mock()
         main_response.status_code = 200
-        
+
         # ランキングメッセージのレスポンス
         ranking_response = Mock()
         ranking_response.status_code = 200
-        
+
         # リクエストの順番に応じてレスポンスを返す
         mock_post.side_effect = [main_response, ranking_response]
 
@@ -150,13 +150,13 @@ class TestNotifier(unittest.TestCase):
 
         # アサーション - 2回のリクエストが送信されたことを確認
         self.assertEqual(mock_post.call_count, 2)
-        
+
         # 1回目（メインメッセージ）の呼び出しを確認
         first_call = mock_post.call_args_list[0]
         self.assertEqual(first_call[0][0], "https://discord.com/api/webhooks/test")
         first_payload = json.loads(first_call[1]["data"])
         self.assertEqual(first_payload["content"], test_summary)
-        
+
         # 2回目（ランキング）の呼び出しを確認
         second_call = mock_post.call_args_list[1]
         self.assertEqual(second_call[0][0], "https://discord.com/api/webhooks/test")
@@ -171,7 +171,7 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         # メインメッセージでエラー
         main_response = Mock()
         main_response.status_code = 400
@@ -192,15 +192,15 @@ class TestNotifier(unittest.TestCase):
         # モック設定
         mock_config.discord_webhook_url = "https://discord.com/api/webhooks/test"
         mock_config.request_timeout = 10
-        
+
         # メインメッセージのレスポンス
         main_response = Mock()
         main_response.status_code = 200
-        
+
         # ランキングメッセージのレスポンス
         ranking_response = Mock()
         ranking_response.status_code = 200
-        
+
         mock_post.side_effect = [main_response, ranking_response]
 
         # テスト実行（要約なし）


### PR DESCRIPTION
## Summary
- Gemini要約をメインメッセージ、ランキング詳細を詳細メッセージとして分割送信
- 要約が視覚的に目立ち、詳細は別メッセージでコードブロック形式で表示
- WebHookの制限により真のスレッド機能は実装困難だったため分割方式で実現

## Test plan
- [ ] Discord WebHookで2つのメッセージが順次送信されることを確認
- [ ] 要約メッセージとランキング詳細メッセージの両方が正常表示されることを確認
- [ ] テストスイートが全て成功することを確認

## Changes
- `send_discord_message_with_thread`関数を新規追加
- メインメッセージ（要約）とランキングメッセージを分割送信
- 詳細ランキングはコードブロック形式で見やすく表示
- 包括的なテストケースを追加

🤖 Generated with [Claude Code](https://claude.ai/code)