### PR TITLE
fix: GitHub ActionsでDISCORD_THREAD_ID環境変数を追加

### DIFF
--- a/.github/workflows/daily-ranking.yml
+++ b/.github/workflows/daily-ranking.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Kindleランキング通知を実行
       env:
         DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        DISCORD_THREAD_ID: ${{ secrets.DISCORD_THREAD_ID }}
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: uv run python src/main.py
 


### PR DESCRIPTION
## Summary
- GitHub ActionsのワークフローでDISCORD_THREAD_ID環境変数が設定されていなかった問題を修正
- 手元では正常にスレッドに送信されるが、GitHub Actionsではメインチャンネルに送信されていた

## Changes  
- `.github/workflows/daily-ranking.yml`にDISCORD_THREAD_ID環境変数を追加

## Test plan
- Repository secretsにDISCORD_THREAD_ID=1381242925043810345が設定済み
- ワークフローの手動実行でスレッドに正常送信されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)